### PR TITLE
README: add Quay build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Open Source Voting Results Reporter (ORR)
 
 [![Build Status](https://travis-ci.org/OSVTAC/osv-results-reporter.svg?branch=master)](https://travis-ci.org/OSVTAC/osv-results-reporter)
+[![Docker Repository on Quay](https://quay.io/repository/osvtac/osv-results-reporter/status "Docker Repository on Quay")](https://quay.io/repository/osvtac/osv-results-reporter)
 
 ## Election results report generator (HTML/PDF/XLS)
 


### PR DESCRIPTION
Add a build badge for the container image. This will badge will show the
build status for master.

TODO: move the Quay repo to point to the github.com/OSVTAC repo instead
of github.com/philips repo once the permission has been approved.