### PR TITLE
kube: initial commit

### DIFF
--- a/kube/README.md
+++ b/kube/README.md
@@ -1,0 +1,24 @@
+## Using ORR on Kubernetes
+
+**Run the webserver**
+
+```
+kubectl create -f orr.yaml
+```
+
+**Use the proxy to visit**
+
+```
+```
+
+## Debugging
+
+**Get ORR logs**
+
+```
+kubectl logs $(kubectl get pod -l app=orr -o=jsonpath='{.items[0].metadata.name}') orr
+```
+
+### TODO
+
+- Add a git puller to download data from git vs using sample data

--- a/kube/orr.yaml
+++ b/kube/orr.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: orr
+  labels:
+    app: orr
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: orr
+  template:
+    metadata:
+      name: orr
+      labels:
+        app: orr
+    spec:
+      volumes:
+      - name: shared-data
+        emptyDir: {}
+      containers:
+      - name: nginx
+        image: nginx
+        volumeMounts:
+        - name: shared-data
+          mountPath: /usr/share/nginx/html
+      - name: orr
+        image: quay.io/osvtac/osv-results-reporter
+        volumeMounts:
+        - name: shared-data
+          mountPath: /web-data
+        args: ["--output-dir", "/web-data", "--input", "/app/sampledata/test-minimal", "--template", "/app/templates/test-minimal"]
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: orr
+spec:
+  selector:
+    app: orr
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80


### PR DESCRIPTION
Initial pass at getting this running under Kubernetes. Hitting a
traceback using the example template though.

```
Traceback (most recent call last):
  File "/usr/local/bin/orr", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/orr/main.py", line 411, in main
    deterministic=deterministic)
  File "/usr/local/lib/python3.6/site-packages/orr/main.py", line 361, in run
    context=context, test_mode=test_mode)
  File "/usr/local/lib/python3.6/site-packages/orr/main.py", line 278, in render_template_dir
    context=context, test_mode=test_mode)
  File "/usr/local/lib/python3.6/site-packages/orr/utils.py", line 346, in process_template
    rendered = template.render(context)
  File "/usr/local/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/local/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "/app/templates/test-minimal/index.html", line 19, in top-level template code
    {% do subtemplate('results-summary.html', output_path) %}
  File "/usr/local/lib/python3.6/site-packages/orr/templating.py", line 185, in subtemplate
    context=context)
  File "/usr/local/lib/python3.6/site-packages/orr/utils.py", line 340, in process_template
    template = env.get_template(template_name)
  File "/usr/local/lib/python3.6/site-packages/jinja2/loaders.py", line 187, in get_source
    raise TemplateNotFound(template)
jinja2.exceptions.TemplateNotFound: results-summary.html
```